### PR TITLE
Create schema for initial entities

### DIFF
--- a/backend/api/clubs/config/routes.json
+++ b/backend/api/clubs/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/clubs",
+      "handler": "clubs.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/clubs/count",
+      "handler": "clubs.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/clubs/:id",
+      "handler": "clubs.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/clubs",
+      "handler": "clubs.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/clubs/:id",
+      "handler": "clubs.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/clubs/:id",
+      "handler": "clubs.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/clubs/controllers/clubs.js
+++ b/backend/api/clubs/controllers/clubs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/clubs/models/clubs.js
+++ b/backend/api/clubs/models/clubs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/clubs/models/clubs.settings.json
+++ b/backend/api/clubs/models/clubs.settings.json
@@ -1,0 +1,45 @@
+{
+  "kind": "collectionType",
+  "collectionName": "clubs",
+  "info": {
+    "name": "clubs"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": false,
+      "unique": true
+    },
+    "email": {
+      "type": "email",
+      "unique": true
+    },
+    "president": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "location": {
+      "type": "string"
+    },
+    "club_type": {
+      "type": "enumeration",
+      "enum": [
+        "academic_and_faculty",
+        "sport_and_fitness",
+        "art_and_culture",
+        "general_interest",
+        "activist_and_partisan",
+        "religion_and_spirituality"
+      ]
+    }
+  }
+}

--- a/backend/api/clubs/services/clubs.js
+++ b/backend/api/clubs/services/clubs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/college-services/config/routes.json
+++ b/backend/api/college-services/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/college-services",
+      "handler": "college-services.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/college-services/count",
+      "handler": "college-services.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/college-services/:id",
+      "handler": "college-services.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/college-services",
+      "handler": "college-services.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/college-services/:id",
+      "handler": "college-services.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/college-services/:id",
+      "handler": "college-services.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/college-services/controllers/college-services.js
+++ b/backend/api/college-services/controllers/college-services.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/college-services/models/college-services.js
+++ b/backend/api/college-services/models/college-services.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/college-services/models/college-services.settings.json
+++ b/backend/api/college-services/models/college-services.settings.json
@@ -1,0 +1,22 @@
+{
+  "kind": "collectionType",
+  "collectionName": "college_services",
+  "info": {
+    "name": "college services"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    }
+  }
+}

--- a/backend/api/college-services/services/college-services.js
+++ b/backend/api/college-services/services/college-services.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/courses/config/routes.json
+++ b/backend/api/courses/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/courses",
+      "handler": "courses.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/courses/count",
+      "handler": "courses.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/courses/:id",
+      "handler": "courses.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/courses",
+      "handler": "courses.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/courses/:id",
+      "handler": "courses.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/courses/:id",
+      "handler": "courses.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/courses/controllers/courses.js
+++ b/backend/api/courses/controllers/courses.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/courses/models/courses.js
+++ b/backend/api/courses/models/courses.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/courses/models/courses.settings.json
+++ b/backend/api/courses/models/courses.settings.json
@@ -13,8 +13,8 @@
       "type": "string"
     },
     "program": {
-      "via": "courses",
-      "model": "programs"
+      "model": "programs",
+      "via": "courses"
     },
     "sections": {
       "collection": "sections",
@@ -24,6 +24,9 @@
       "type": "string"
     },
     "overview": {
+      "type": "richtext"
+    },
+    "prerequisites": {
       "type": "richtext"
     }
   }

--- a/backend/api/courses/models/courses.settings.json
+++ b/backend/api/courses/models/courses.settings.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "courses",
+  "info": {
+    "name": "courses"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "program": {
+      "via": "courses",
+      "model": "programs"
+    },
+    "sections": {
+      "collection": "sections",
+      "via": "course"
+    },
+    "course_code": {
+      "type": "string"
+    },
+    "overview": {
+      "type": "richtext"
+    }
+  }
+}

--- a/backend/api/courses/services/courses.js
+++ b/backend/api/courses/services/courses.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/deadlines/config/routes.json
+++ b/backend/api/deadlines/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/deadlines",
+      "handler": "deadlines.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/deadlines/count",
+      "handler": "deadlines.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/deadlines/:id",
+      "handler": "deadlines.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/deadlines",
+      "handler": "deadlines.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/deadlines/:id",
+      "handler": "deadlines.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/deadlines/:id",
+      "handler": "deadlines.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/deadlines/controllers/deadlines.js
+++ b/backend/api/deadlines/controllers/deadlines.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/deadlines/models/deadlines.js
+++ b/backend/api/deadlines/models/deadlines.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/deadlines/models/deadlines.settings.json
+++ b/backend/api/deadlines/models/deadlines.settings.json
@@ -1,0 +1,19 @@
+{
+  "kind": "collectionType",
+  "collectionName": "deadlines",
+  "info": {
+    "name": "deadlines"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "date": {
+      "type": "date"
+    },
+    "description": {
+      "type": "richtext"
+    }
+  }
+}

--- a/backend/api/deadlines/services/deadlines.js
+++ b/backend/api/deadlines/services/deadlines.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/departments/config/routes.json
+++ b/backend/api/departments/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/departments",
+      "handler": "departments.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/departments/count",
+      "handler": "departments.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/departments/:id",
+      "handler": "departments.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/departments",
+      "handler": "departments.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/departments/:id",
+      "handler": "departments.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/departments/:id",
+      "handler": "departments.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/departments/controllers/departments.js
+++ b/backend/api/departments/controllers/departments.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/departments/models/departments.js
+++ b/backend/api/departments/models/departments.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/departments/models/departments.settings.json
+++ b/backend/api/departments/models/departments.settings.json
@@ -1,0 +1,22 @@
+{
+  "kind": "collectionType",
+  "collectionName": "departments",
+  "info": {
+    "name": "departments"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": false,
+      "unique": true
+    },
+    "programs": {
+      "via": "department",
+      "collection": "programs"
+    }
+  }
+}

--- a/backend/api/departments/services/departments.js
+++ b/backend/api/departments/services/departments.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/professors/config/routes.json
+++ b/backend/api/professors/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/professors",
+      "handler": "professors.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/professors/count",
+      "handler": "professors.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/professors/:id",
+      "handler": "professors.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/professors",
+      "handler": "professors.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/professors/:id",
+      "handler": "professors.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/professors/:id",
+      "handler": "professors.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/professors/controllers/professors.js
+++ b/backend/api/professors/controllers/professors.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/professors/models/professors.js
+++ b/backend/api/professors/models/professors.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/professors/models/professors.settings.json
+++ b/backend/api/professors/models/professors.settings.json
@@ -1,0 +1,23 @@
+{
+  "kind": "collectionType",
+  "collectionName": "professors",
+  "info": {
+    "name": "professors"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "sections": {
+      "collection": "sections",
+      "via": "professor"
+    },
+    "email": {
+      "type": "string"
+    }
+  }
+}

--- a/backend/api/professors/services/professors.js
+++ b/backend/api/professors/services/professors.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/programs/config/routes.json
+++ b/backend/api/programs/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/programs",
+      "handler": "programs.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/programs/count",
+      "handler": "programs.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/programs/:id",
+      "handler": "programs.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/programs",
+      "handler": "programs.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/programs/:id",
+      "handler": "programs.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/programs/:id",
+      "handler": "programs.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/programs/controllers/programs.js
+++ b/backend/api/programs/controllers/programs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/programs/models/programs.js
+++ b/backend/api/programs/models/programs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/programs/models/programs.settings.json
+++ b/backend/api/programs/models/programs.settings.json
@@ -1,0 +1,36 @@
+{
+  "kind": "collectionType",
+  "collectionName": "programs",
+  "info": {
+    "name": "programs"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "courses": {
+      "collection": "courses",
+      "via": "program"
+    },
+    "department": {
+      "model": "departments",
+      "via": "programs"
+    },
+    "overview": {
+      "type": "richtext"
+    },
+    "credential": {
+      "type": "string"
+    },
+    "credits": {
+      "type": "integer"
+    },
+    "offered_on": {
+      "type": "string"
+    }
+  }
+}

--- a/backend/api/programs/models/programs.settings.json
+++ b/backend/api/programs/models/programs.settings.json
@@ -13,8 +13,8 @@
       "type": "string"
     },
     "courses": {
-      "collection": "courses",
-      "via": "program"
+      "via": "program",
+      "collection": "courses"
     },
     "department": {
       "model": "departments",

--- a/backend/api/programs/services/programs.js
+++ b/backend/api/programs/services/programs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/sections/config/routes.json
+++ b/backend/api/sections/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/sections",
+      "handler": "sections.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/sections/count",
+      "handler": "sections.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/sections/:id",
+      "handler": "sections.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/sections",
+      "handler": "sections.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/sections/:id",
+      "handler": "sections.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/sections/:id",
+      "handler": "sections.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/sections/controllers/sections.js
+++ b/backend/api/sections/controllers/sections.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/sections/models/sections.js
+++ b/backend/api/sections/models/sections.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/sections/models/sections.settings.json
+++ b/backend/api/sections/models/sections.settings.json
@@ -1,0 +1,61 @@
+{
+  "kind": "collectionType",
+  "collectionName": "sections",
+  "info": {
+    "name": "sections"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "professor": {
+      "via": "sections",
+      "model": "professors"
+    },
+    "course": {
+      "via": "sections",
+      "model": "courses"
+    },
+    "start_time": {
+      "type": "time",
+      "unique": false
+    },
+    "end_time": {
+      "required": false,
+      "private": false,
+      "unique": false,
+      "type": "time"
+    },
+    "maximum_enrolment": {
+      "type": "integer"
+    },
+    "actual_enrolment": {
+      "type": "integer"
+    },
+    "remaining_enrolment": {
+      "type": "integer"
+    },
+    "actual_waitlist": {
+      "type": "integer"
+    },
+    "building": {
+      "type": "string"
+    },
+    "room": {
+      "type": "string"
+    },
+    "days": {
+      "type": "string"
+    },
+    "semester_start": {
+      "type": "date"
+    },
+    "semester_end": {
+      "type": "date"
+    }
+  }
+}

--- a/backend/api/sections/services/sections.js
+++ b/backend/api/sections/services/sections.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};


### PR DESCRIPTION
# Summary

We need to define what properties the data will have and how they will relate to each other. We don't need to know all of these right now, but we need to know enough so we can start collecting data.

I'm starting us out with the following:

![initial-schema-diagram](https://user-images.githubusercontent.com/22126263/85391304-d830ef80-b4fe-11ea-81e8-48c1c3bb0f47.png)

I still haven't added anything to tell a user about the exam schedule of a given section, but this should be as easy as adding a separate content type just for exam schedules and having each entry there point to some section.

There are some content types that are not connected to other content types. These are very easy to deal with because we can just input the data into Strapi without needing to know how to connect it to other content types.

## Data Sources

### Isolated content types

- Clubs data can be found here: http://www.thedsu.ca/club-collective/
- College services (which we will potentially enter by hand) can be found here: https://www.douglascollege.ca/student-services
- Deadlines are here: https://www.douglascollege.ca/programs-courses/general-information/dates-and-deadlines

### Content types with relations

- Professors: https://www.douglascollege.ca/programs-courses/faculties
- Sections: https://www.douglascollege.ca/student-services (we only need sections from courses we care about)
- Courses: https://www.douglascollege.ca/programs-courses/catalogue/courses (we only need courses that belong to programs we care about)
- Programs: https://www.douglascollege.ca/programs-courses/catalogue/programs (we need not include all programs because we should only get data for the ones that we care about)
- Departments: we can just infer the departments from the programs since this is just an array of pointers to different programs