### PR TITLE
feat: automatically set default user permissions upon server start

### DIFF
--- a/backend/config/functions/bootstrap.js
+++ b/backend/config/functions/bootstrap.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 /**
  * An asynchronous bootstrap function that runs before
@@ -10,4 +10,44 @@
  * See more details here: https://strapi.io/documentation/v3.x/concepts/configurations.html#bootstrap
  */
 
-module.exports = () => {};
+const setAuthenticatedUserPermissions = async (strapi) => {
+  const authenticatedUsers = await strapi
+    .query("role", "users-permissions")
+    .findOne({ type: "authenticated" });
+
+  authenticatedUsers.permissions.forEach((permission) => {
+    if (permission.enabled === false) {
+      const newPermission = permission;
+      newPermission.enabled = true;
+      strapi
+        .query("permission", "users-permissions")
+        .update({ id: newPermission.id }, newPermission);
+    }
+  });
+};
+
+const setPublicUserPermissions = async (strapi) => {
+  const publicUsers = await strapi
+    .query("role", "users-permissions")
+    .findOne({ type: "public" });
+
+  publicUsers.permissions.forEach((permission) => {
+    if (
+      permission.type === "application" &&
+      (permission.action === "count" ||
+        permission.action === "find" ||
+        permission.action === "findone")
+    ) {
+      const newPermission = permission;
+      newPermission.enabled = true;
+      strapi
+        .query("permission", "users-permissions")
+        .update({ id: newPermission.id }, newPermission);
+    }
+  });
+};
+
+module.exports = async () => {
+  await setAuthenticatedUserPermissions(strapi);
+  await setPublicUserPermissions(strapi);
+};

--- a/backend/config/functions/bootstrap.js
+++ b/backend/config/functions/bootstrap.js
@@ -14,9 +14,8 @@ const setAuthenticatedUserPermissions = async (strapi) => {
   const authenticatedUsers = await strapi
     .query("role", "users-permissions")
     .findOne({ type: "authenticated" });
-
   authenticatedUsers.permissions.forEach((permission) => {
-    if (permission.enabled === false) {
+    if (permission.type === "application") {
       const newPermission = permission;
       newPermission.enabled = true;
       strapi


### PR DESCRIPTION
Strapi as of version 3.0.2 stores the "users-permissions" plugin's configuration in the database rather than a configuration file. This makes it cumbersome to synchronize permissions between development and production databases. I created two bootstrap functions that set default permissions for authenticated users and public users.

The defaults are:
- authenticated users get all permissions so they can perform read, write, update, and delete queries
- public users only get read access through `find`, `fineone`, and `count` queries